### PR TITLE
Fix bug in OBJ exporting, plus a couple of minor enhancements

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,3 +19,11 @@ impl From<std::io::Error> for Error {
         Error::new(&e.to_string())
     }
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.details)
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/obj/format_writer.rs
+++ b/src/obj/format_writer.rs
@@ -21,15 +21,17 @@ impl FormatWriter {
                 for v in vertices {
                     writer.write_all(" ".as_ref()).unwrap();
                     writer.write_all(format!("{}", v.vertex).as_ref()).unwrap();
-                    if let Some(x) = v.normal {
-                        writer.write_all(format!("/{}", x).as_ref()).unwrap();
-                    }
                     if let Some(x) = v.texture {
                         if v.normal.is_none() {
                             writer.write_all("/".as_ref()).unwrap();
                         }
                         writer.write_all(format!("/{}", x).as_ref()).unwrap();
+                    } else {
+                        writer.write_all("/".as_ref()).unwrap();
                     }
+                    if let Some(x) = v.normal {
+                        writer.write_all(format!("/{}", x).as_ref()).unwrap();
+                    } 
                 }
             }
             Entity::Point { vertices } => {

--- a/src/obj/read_lexer.rs
+++ b/src/obj/read_lexer.rs
@@ -14,7 +14,7 @@ impl ReadLexer {
     /// Will read from the given `BufRead`as long as it is not EOF.\
     /// When an entity is parsed, the given callback is invoked and the entity is inserted into it as parameter.\
     /// Will return `Ok(())` if successful or an `Error` (if parsing failed).
-    pub fn read_to_end<R: BufRead>(reader: &mut R, callback: impl Fn(Entity)) -> Result<(), Error> {
+    pub fn read_to_end<R: BufRead>(reader: &mut R, mut callback: impl FnMut(Entity)) -> Result<(), Error> {
         for l in reader.lines() {
             let s: String = l?;
             let mut split = s.split_whitespace();


### PR DESCRIPTION
Hi! I'm using this crate in [my project](https://github.com/setzer22/blackjack) and I've noticed there was a bug in exporting. The order of UV and vertex normals was inverted: When exporting a mesh with normals and no UVs, it should look like this: `f 123//345`, but the exporter put the normal on the second slot `f 123/345`. The second slot is meant for UV coordinates, and if there are no UVs it needs to be specified as empty.

Additionally, there's a couple of minor improvements to the API